### PR TITLE
Adding in loading named block

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ We accept any args that the tinymce editor does.
 export default class Application extends Controller {
     plugins: string[] = [TinymceEditorPlugins.EMOTICONS];
     toolbar: string[] = ['emoticons'];
+    @tracked value = 'Much wow';
     ...
 }
 
-<TinymceEditor @plugins={{this.plugins}} @toolbar={{this.toolbar}} />
+<TinymceEditor @plugins={{this.plugins}} @toolbar={{this.toolbar}} @value={{this.value}} @onUpdate={{this.onUpdate}}>
+    <:loading>
+        Hey, Im shown while tinymce is initializing. This might be helpful when rendering in fastboot
+    </:loading>
+</TinymceEditor>
 ```
 
 ## Contributing

--- a/addon/components/tinymce-editor.hbs
+++ b/addon/components/tinymce-editor.hbs
@@ -1,7 +1,10 @@
 <div class="tinymce-editor" ...attributes {{did-insert this.initEditor}} {{did-update this.updateValue @value}}>
-    {{#if hasBlock}}
+    {{#if (has-block)}}
         {{yield}}
     {{else}}
-        <textarea id={{this.uniqueId}}></textarea>
+        <textarea id={{this.uniqueId}} style="visibility: hidden;"></textarea>
+        {{#if this.loading}}
+            {{yield to="loading"}}
+        {{/if}}
     {{/if}}
 </div>

--- a/addon/components/tinymce-editor.hbs
+++ b/addon/components/tinymce-editor.hbs
@@ -2,7 +2,8 @@
     {{#if (has-block)}}
         {{yield}}
     {{else}}
-        <textarea id={{this.uniqueId}} style="visibility: hidden;"></textarea>
+        <textarea id={{this.uniqueId}} style="visibility: hidden; height: 0;"></textarea>
+
         {{#if this.loading}}
             {{yield to="loading"}}
         {{/if}}

--- a/addon/components/tinymce-editor.ts
+++ b/addon/components/tinymce-editor.ts
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 // https://github.com/ef4/ember-auto-import/issues/169#issuecomment-479546122
 type RawEditorSettings = import('tinymce').RawEditorSettings;
@@ -286,6 +287,8 @@ export interface TinymceEditorArgs extends RawEditorSettings {
 export default class TinymceEditor extends Component<TinymceEditorArgs> {
     private instance?: Editor;
 
+    @tracked loading = true;
+
     /**
      * Tinymce wants to load its own theme and skin. This tells tinymce where to try and load the items from
      *
@@ -410,7 +413,7 @@ export default class TinymceEditor extends Component<TinymceEditorArgs> {
             editor.setDirty(false);
 
             editor.on('change keyup setcontent', this.handleEditorChange.bind(this));
-
+            this.loading = false;
             this.args.onInit?.(initEvent, editor);
         }
     };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "ember-cli-babel": "^7.21.0",
         "ember-cli-htmlbars": "^5.2.0",
         "ember-cli-typescript": "^4.1.0",
+        "ember-named-blocks-polyfill": "^0.2.4",
         "tinymce": "^5.7.0"
     },
     "devDependencies": {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,10 +1,15 @@
 <textarea>
     hello
 </textarea>
+
 <TinymceEditor
     @plugins={{this.plugins}}
     @toolbar={{this.toolbar}}
     @onInit={{this.onInit}}
     @value={{this.value}}
     @onUpdate={{this.onUpdate}}
-/>
+>
+    <:loading>
+        Test
+    </:loading>
+</TinymceEditor>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5493,6 +5493,14 @@ ember-modifier-manager-polyfill@^1.1.0:
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
 
+ember-named-blocks-polyfill@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-named-blocks-polyfill/-/ember-named-blocks-polyfill-0.2.4.tgz#f5f30711ee89244927b55aae7fa9630edaadc974"
+  integrity sha512-PsohC7ejjS7V++6i/JSy0pl1hXLV3IS3Qs+O7SrjIPYcg1UEmUwqgPiDmXqNgy0p2dc5TK5bIJTtX8wofCI63Q==
+  dependencies:
+    ember-cli-babel "^7.19.0"
+    ember-cli-version-checker "^5.1.1"
+
 ember-qunit@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-4.6.0.tgz#ad79fd3ff00073a8779400cc5a4b44829517590f"


### PR DESCRIPTION
I was seeing the original (non styled) `textarea` in Fastboot. So this pull request hides that text area using visibility hidden, and goes one step further to provide a loading named block that gets shown before the tinymce instance has been initialized so we can show some sort of loading indicator